### PR TITLE
Docs for docker and fix typo in notes.txt

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,5 @@
+# Docker
+
+* Building for docker can be done with ```docker build -t mailsend-go .```. This will also fetch the golang image and create a intermediate image (about 820MB in total). If space is a concern for you, remove them with ```docker rmi golang:1.13.7``` and ```docker image prune```
+
+* Running with docker can be done as any other docker image. Everything after the image name will be passed to the program. Example: ```docker run -it --rm mailsend-go -V``` will show the version

--- a/docs/notes.txt
+++ b/docs/notes.txt
@@ -2,7 +2,7 @@ My personal note
 ================
 * Update version in code
 * Update latest version in markdown docs/version.md
-* Update docs/ChagneLog.md
+* Update docs/ChangeLog.md
 * Generate docs, Update usage (make dev;make clean;make)
 * Compile
 * Test


### PR DESCRIPTION
- Documents docker in ```docs/docker.md```
- Changes _Cha**gn**eLog.md_ to _Cha**ng**eLog.md_ in ```docs/notes.txt```

Also, why is the develop branch trailing the master branch ?
Please merge master into develop so that we can send PR's to develop instead