### PR TITLE
Known SMTP servers: add office365

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -57,7 +57,7 @@ Certificate of smtp.gmail.com:
 ### Use default settings for well known mail providers
 
 Don't worry about the settings of -smtp, -port and -ssl for well known mail
-providers. This works for gmail, yahoo, outlook, gmx, zoho and aol.
+providers. This works for gmail, yahoo, office365, outlook, gmx, zoho and aol.
 
       mailsend-go -info -use gmail
 

--- a/main.go
+++ b/main.go
@@ -239,7 +239,7 @@ func fatalError(format string, a ...interface{}) {
 
 // Validate numeric value
 func (v NumberValidator) Validate(val interface{}) (bool, error) {
-	logDebug("in Numberic validator default: %d\n", v.Default)
+	logDebug("in Number validator default: %d\n", v.Default)
 	num := val.(int)
 	logDebug("num: %d\n", num)
 	if num == 0 { // not specified
@@ -587,7 +587,7 @@ func showUsageAndExit() {
                            unless '-use' is set.
   -use mailprovider      - Arranges -smtp, -port and -ssl for you when using
                            a well known mailprovider. Allowed values:
-                           gmail, yahoo, outlook, gmx, zoho, aol
+                           gmail, yahoo, outlook, office365, gmx, zoho, aol
   -port port             - port of SMTP server. Default is 587
   -domain domain         - domain name for SMTP HELO. Default is localhost
   -info                  - Print info about SMTP server
@@ -966,8 +966,11 @@ func main() {
 				mailsend.options.SMTPServer = "smtp.mail.yahoo.com"
 				mailsend.options.Port = 465
 				mailsend.options.Ssl = true
+			} else if args[i] == "office365" {
+				mailsend.options.SMTPServer = "smtp.office365.com"
+				mailsend.options.Port = 587
 			} else if args[i] == "outlook" {
-				mailsend.options.SMTPServer = "smtp.live.com"
+				mailsend.options.SMTPServer = "smtp-mail.outlook.com"
 				mailsend.options.Port = 587
 			} else if args[i] == "gmx" {
 				mailsend.options.SMTPServer = "smtp.gmx.com"
@@ -981,7 +984,7 @@ func main() {
 				mailsend.options.SMTPServer = "smtp.aol.com"
 				mailsend.options.Port = 587
 			} else {
-				fatalError("Mailprovider '%s' not known\n", args[i])
+				fatalError("Mail provider '%s' not known\n", args[i])
 			}
 		} else if arg == "-smtp" || arg == "--smtp" {
 			i++


### PR DESCRIPTION
This PR updates the outdated SMTP server `smtp.live.com`.
It also adds the option `office365` to the values allowed with `use`.