### PR TITLE
Add Winget Releaser workflow

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,15 @@
+name: Publish to Winget
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: muquit.mailsend-go
+          installers-regex: 'windows-\w+\.d\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
[This action](https://github.com/vedantmgoyal2009/winget-releaser) automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them (see #74)

**Before merging this:**
1. Add a **classic** PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN`. You can go to this URL to create it: https://github.com/settings/tokens/new?scopes=public_repo

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @muquit. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been created with WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+created+with+WinGet+Releaser).
